### PR TITLE
2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,52 @@
-# Elasticsearch Dockerfile
-#
-#     https://github.com/dockerfile/elasticsearch
-#
 FROM openjdk:8-jre
 
-ENV ELASTICSEARCH_VERSION 2.3.5
-ENV PATH /usr/share/elasticsearch/bin:$PATH
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+  && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu \
+  && gosu nobody true
 
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html
 # https://packages.elasticsearch.org/GPG-KEY-elasticsearch
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
-RUN echo "deb http://packages.elasticsearch.org/elasticsearch/2.x/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+
+ENV ELASTICSEARCH_VERSION 2.3.5
+ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
+
+RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list
+
 RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends elasticsearch=$ELASTICSEARCH_VERSION \
   && rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+
+WORKDIR /usr/share/elasticsearch
+
 RUN set -ex \
   && for path in \
-    /usr/share/elasticsearch/data \
-    /usr/share/elasticsearch/logs \
-    /usr/share/elasticsearch/config \
-    /usr/share/elasticsearch/config/scripts \
+    ./data \
+    ./logs \
+    ./config \
+    ./config/scripts \
   ; do \
     mkdir -p "$path"; \
     chown -R elasticsearch:elasticsearch "$path"; \
   done
 
-ADD config/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+COPY config ./config
 
 VOLUME /usr/share/elasticsearch/data
-USER elasticsearch
-WORKDIR /usr/share/elasticsearch
-EXPOSE 9200 9300
 
-ENTRYPOINT ["elasticsearch"]
+COPY docker-entrypoint.sh /
+
+EXPOSE 9200 9300
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["elasticsearch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 # https://packages.elasticsearch.org/GPG-KEY-elasticsearch
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
-ENV ELASTICSEARCH_VERSION 2.3.5
+ENV ELASTICSEARCH_VERSION 2.4.0
 ENV ELASTICSEARCH_REPO_BASE http://packages.elasticsearch.org/elasticsearch/2.x/debian
 
 RUN echo "deb $ELASTICSEARCH_REPO_BASE stable main" > /etc/apt/sources.list.d/elasticsearch.list

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,5 +1,5 @@
 path:
-  data: /data/data
-  logs: /data/log
-  plugins: /data/plugins
-  work: /data/work
+  data: /usr/share/elasticsearch/data
+  logs: /usr/share/elasticsearch/logs
+  plugins: /usr/share/elasticsearch/plugins
+  work: /usr/share/elasticsearch/work

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -3,3 +3,5 @@ path:
   logs: /usr/share/elasticsearch/logs
   plugins: /usr/share/elasticsearch/plugins
   work: /usr/share/elasticsearch/work
+cluster:
+  name: elk

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -1,0 +1,15 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -3,7 +3,7 @@ es.logger.level: INFO
 rootLogger: ${es.logger.level}, console
 logger:
   # log action execution errors for easier debugging
-  action: DEBUG
+  action: Warn
   # reduce the logging for aws, too much is logged under the default INFO
   com.amazonaws: WARN
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+  set -- elasticsearch "$@"
+fi
+
+# Drop root privileges if we are running elasticsearch
+# allow the container to be started with `--user`
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
+  # Change the ownership of /usr/share/elasticsearch/data to elasticsearch
+  chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+
+  set -- gosu elasticsearch "$@"
+  #exec gosu elasticsearch "$BASH_SOURCE" "$@"
+fi
+
+# As argument is not related to elasticsearch,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"


### PR DESCRIPTION
This PR goes towards giantswarm/giantswarm#725. Here we upgrade Elasticsearch to `2.4.0`. We are now using the exact copy of [the official Dockerfile](https://github.com/docker-library/elasticsearch/tree/61100bb78dac9dcdf4485579a4d8762e75f1e0b8/2.4). Once this PR is merged I would like to delete and re-create it to have the fork of the outdated repository gone and some more helpful comments in the README. 

RFR @giantswarm/team-positive  
